### PR TITLE
Change express requirement to <v4

### DIFF
--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
-    "passport": ">= 0.0.0",
+    "passport": "< 4.0.0",
     "passport-box": ">= 0.0.0"
   }
 }


### PR DESCRIPTION
The example app's express config is not compatible with Express v4+. I have modified the package.json to pull up to the latest v3. This should be considered a temp fix. Plan to update app.js to be compatible with the most recent express version.
