### PR TITLE
passport-oauth2@1.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "main": "./lib/",
   "dependencies": {
-    "passport-oauth2": "^1.1.2",
+    "passport-oauth2": "1.3.x",
     "pkginfo": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
update to the latest version of `passport-oauth2` (there are no breaking changes)
